### PR TITLE
fix(Translation): Objects in context caused error

### DIFF
--- a/src/jblond/TwigTrans/Translation.php
+++ b/src/jblond/TwigTrans/Translation.php
@@ -43,9 +43,17 @@ class Translation implements ExtensionInterface
      */
     private static function replaceContext(string $string, array $context): string
     {
+        // Without the brackets there is no need to run the rest of this method.
+        if (mb_strpos($string, '{{') === false) {
+            return $string;
+        }
         foreach ($context as $key => $value) {
             if (is_array($value)) {
                 return self::replaceContext($string, $value);
+            }
+            // Ignore objects, since only simple variables can be used
+            if (is_object($value)) {
+                continue;
             }
             $string = str_replace('{{ ' . $key . ' }}', $value, $string);
         }


### PR DESCRIPTION
Closes #2

Fixes the error when there is an object in the $context. Also checks for brackets before even bothering to run all those str_replace (which could be substantial if your context has a lot of vars in it.

Hope I did this ok? We were just starting to try this out and it was all working fine until I loaded a template with a few objects in it.

Not sure if master is the appropriate target, but since its the only branch...